### PR TITLE
Fix blog

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,4 +1,8 @@
-= forward
+:subtitle: A stack-based programming language.
+
+// tag::preamble[]
+
+= forward: {subtitle}
 Bruno Arias <https://github.com/Bruno-366>
 0.0, Fall 2021: Work in Progress
 :toc:
@@ -6,8 +10,6 @@ Bruno Arias <https://github.com/Bruno-366>
 :toclevels: 3
 
 link:https://github.com/Bruno-366/forward/actions/workflows/asciidoctor-ghpages.yml[image:https://github.com/Bruno-366/forward/actions/workflows/asciidoctor-ghpages.yml/badge.svg[asciidoctor-ghpages]]
-
-// tag::preamble[]
 
 A stack-based programming language.
 Powerful Enough, Simple, Correct.

--- a/README.adoc
+++ b/README.adoc
@@ -16,8 +16,8 @@ Powerful Enough, Simple, Correct.
 
 Documentation:
 - link:https://bruno-366.github.io/forward/[Website]
-- xref:blog/index.adoc#[Development Blog]
-- xref:knowledge-base.adoc#[Knowledge Base]
+- xref:/blog/index.adoc#[Development Blog]
+- xref:/knowledge-base.adoc#[Knowledge Base]
 - link:https://github.com/Bruno-366/forward/blob/gh-pages/ebook.pdf[Ebook]
 
 // end::preamble[]

--- a/blog/composing-grammars.adoc
+++ b/blog/composing-grammars.adoc
@@ -1,17 +1,14 @@
-:relfileprefix: ../
+:subtitle: Composing grammars
+include::/README.adoc[tag=preamble]
 
-include::../README.adoc[tag=preamble]
-
-:relfileprefix:
-
-# Composing grammars
+== {subtitle}
 
 Parsers can be composed using parser combinators,
   footnote:[https://en.wikipedia.org/wiki/Parser_combinator]
 but what about the grammars themselves?
 How does that work?
 
-## From Wikipedia:
+=== From Wikipedia:
 
 In the classic formalization of generative grammars first proposed by Noam Chomsky in the 1950s, a grammar 𝐆 consists of the following components:
   footnote:[https://en.wikipedia.org/wiki/Formal_grammar#The_syntax_of_grammars]
@@ -26,7 +23,7 @@ A grammar is formally defined as the tuple (𝐍, 𝚺, 𝐏, 𝐒).
 
 ---
 
-## Composing regular grammars
+=== Composing regular grammars
 
 The first grammar 𝐆: (𝐍, 𝚺, 𝐏, 𝐒). 
 

--- a/blog/index.adoc
+++ b/blog/index.adoc
@@ -1,10 +1,7 @@
-:relfileprefix: ../
+:subtitle: Posts
+include::/README.adoc[tag=preamble]
 
-include::../README.adoc[tag=preamble]
-
-:relfileprefix:
-
-= Posts
+== {subtitle}
 
 * xref:composing-grammars.adoc[]
 * xref:test-comments.adoc[]

--- a/blog/test-comments.adoc
+++ b/blog/test-comments.adoc
@@ -1,8 +1,4 @@
-:relfileprefix: ../
-
-include::../README.adoc[tag=preamble]
-
-:relfileprefix:
+include::/README.adoc[tag=preamble]
 
 Hello!
 Don't mind me, just testing link:https://utteranc.es/[utterances], A lightweight comments widget built on GitHub issues.


### PR DESCRIPTION
relative transclusion of README, plus header: set subtitle attribute, so that :doctitle: of posts is reasonable